### PR TITLE
Avoid data overriding & added data updater for multi-host compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <java.release>1.8</java.release>
+        <java.release>8</java.release>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -119,6 +119,10 @@
             <id>songoda-public</id>
             <url>https://repo.songoda.com/repository/public/</url>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -132,14 +136,14 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18-R0.1-SNAPSHOT</version>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.9.2</version>
+            <version>2.11.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <java.release>8</java.release>
+        <java.release>1.8</java.release>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -50,7 +50,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.3.0</version>
 
                 <executions>
                     <execution>
@@ -111,6 +111,10 @@
     </pluginRepositories>
 
     <repositories>
+        <repository>
+            <id>spigotmc-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
         <repository>
             <id>songoda-public</id>
             <url>https://repo.songoda.com/repository/public/</url>

--- a/src/main/java/com/songoda/epiclevels/EpicLevels.java
+++ b/src/main/java/com/songoda/epiclevels/EpicLevels.java
@@ -70,7 +70,7 @@ public class EpicLevels extends SongodaPlugin {
 
     @Override
     public void onPluginDisable() {
-        this.dataManager.close();
+        this.dataManager.getUpdater().onDisable();
         this.dataManager.bulkUpdatePlayers(this.playerManager.getPlayers());
         this.dataManager.bulkUpdateBoosts(this.boostManager.getBoosts().values());
 

--- a/src/main/java/com/songoda/epiclevels/EpicLevels.java
+++ b/src/main/java/com/songoda/epiclevels/EpicLevels.java
@@ -70,6 +70,7 @@ public class EpicLevels extends SongodaPlugin {
 
     @Override
     public void onPluginDisable() {
+        this.dataManager.close();
         this.dataManager.bulkUpdatePlayers(this.playerManager.getPlayers());
         this.dataManager.bulkUpdateBoosts(this.boostManager.getBoosts().values());
 

--- a/src/main/java/com/songoda/epiclevels/boost/BoostManager.java
+++ b/src/main/java/com/songoda/epiclevels/boost/BoostManager.java
@@ -73,8 +73,10 @@ public class BoostManager {
         return boost;
     }
 
-    public void clearGlobalBoost() {
-        if (globalBoost == null) return;
+    public Boost clearGlobalBoost() {
+        if (globalBoost == null) return null;
+
         globalBoost.expire();
+        return globalBoost;
     }
 }

--- a/src/main/java/com/songoda/epiclevels/commands/CommandBoost.java
+++ b/src/main/java/com/songoda/epiclevels/commands/CommandBoost.java
@@ -5,8 +5,8 @@ import com.songoda.core.utils.TimeUtils;
 import com.songoda.epiclevels.EpicLevels;
 import com.songoda.epiclevels.boost.Boost;
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
 import java.util.List;
 
@@ -23,9 +23,9 @@ public class CommandBoost extends AbstractCommand {
     protected ReturnType runCommand(CommandSender sender, String... args) {
         if (args.length < 3) return ReturnType.SYNTAX_ERROR;
 
-        Player player = Bukkit.getPlayer(args[0].toLowerCase());
+        OfflinePlayer player = Bukkit.getOfflinePlayer(args[0]);
 
-        if (player == null) {
+        if (!instance.getPlayerManager().containsPlayer(player.getUniqueId())) {
             instance.getLocale().getMessage("command.general.notonline")
                     .processPlaceholder("name", args[0])
                     .sendPrefixedMessage(sender);
@@ -52,6 +52,7 @@ public class CommandBoost extends AbstractCommand {
         Boost boost = new Boost(duration + System.currentTimeMillis(), multiplier);
         instance.getBoostManager().addBoost(player.getUniqueId(), boost);
         instance.getDataManager().createBoost(player.getUniqueId(), boost);
+        instance.getDataManager().getUpdater().sendBoostCreate(player.getUniqueId(), duration, multiplier, sender.getName());
 
         instance.getLocale().getMessage("event.boost.success")
                 .processPlaceholder("player", player.getName())
@@ -64,7 +65,7 @@ public class CommandBoost extends AbstractCommand {
                     .processPlaceholder("player", sender.getName())
                     .processPlaceholder("multiplier", multiplier)
                     .processPlaceholder("duration", TimeUtils.makeReadable(duration))
-                    .sendPrefixedMessage(player);
+                    .sendPrefixedMessage(player.getPlayer());
 
         return ReturnType.SUCCESS;
     }

--- a/src/main/java/com/songoda/epiclevels/commands/CommandGlobalBoost.java
+++ b/src/main/java/com/songoda/epiclevels/commands/CommandGlobalBoost.java
@@ -43,6 +43,7 @@ public class CommandGlobalBoost extends AbstractCommand {
         Boost boost = new Boost(duration + System.currentTimeMillis(), multiplier);
         instance.getBoostManager().setGlobalBoost(boost);
         instance.getDataManager().createBoost(null, boost);
+        instance.getDataManager().getUpdater().sendBoostCreate(null, duration, multiplier, sender.getName());
 
         instance.getLocale().getMessage("event.boost.globalsuccess")
                 .processPlaceholder("multiplier", multiplier)

--- a/src/main/java/com/songoda/epiclevels/commands/CommandRemoveBoost.java
+++ b/src/main/java/com/songoda/epiclevels/commands/CommandRemoveBoost.java
@@ -2,6 +2,7 @@ package com.songoda.epiclevels.commands;
 
 import com.songoda.core.commands.AbstractCommand;
 import com.songoda.epiclevels.EpicLevels;
+import com.songoda.epiclevels.boost.Boost;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
@@ -21,16 +22,20 @@ public class CommandRemoveBoost extends AbstractCommand {
     protected ReturnType runCommand(CommandSender sender, String... args) {
         if (args.length != 1) return ReturnType.SYNTAX_ERROR;
 
-        OfflinePlayer player = Bukkit.getPlayer(args[0]);
+        OfflinePlayer player = Bukkit.getOfflinePlayer(args[0]);
 
-        if (player == null) {
+        if (!instance.getPlayerManager().containsPlayer(player.getUniqueId())) {
             instance.getLocale().getMessage("command.general.notonline")
                     .processPlaceholder("name", args[0])
                     .sendPrefixedMessage(sender);
             return ReturnType.FAILURE;
         }
 
-        instance.getBoostManager().removeBoost(player.getUniqueId());
+        Boost boost = instance.getBoostManager().removeBoost(player.getUniqueId());
+        if (boost != null) {
+            instance.getDataManager().deleteBoost(boost);
+        }
+        instance.getDataManager().getUpdater().sendBoostRemove(player.getUniqueId());
         instance.getLocale().getMessage("command.removeboost.success")
                 .processPlaceholder("player", player.getName())
                 .sendPrefixedMessage(sender);

--- a/src/main/java/com/songoda/epiclevels/commands/CommandRemoveGlobalBoost.java
+++ b/src/main/java/com/songoda/epiclevels/commands/CommandRemoveGlobalBoost.java
@@ -2,6 +2,7 @@ package com.songoda.epiclevels.commands;
 
 import com.songoda.core.commands.AbstractCommand;
 import com.songoda.epiclevels.EpicLevels;
+import com.songoda.epiclevels.boost.Boost;
 import org.bukkit.command.CommandSender;
 
 import java.util.List;
@@ -17,7 +18,11 @@ public class CommandRemoveGlobalBoost extends AbstractCommand {
 
     @Override
     protected ReturnType runCommand(CommandSender sender, String... args) {
-        instance.getBoostManager().clearGlobalBoost();
+        Boost boost = instance.getBoostManager().clearGlobalBoost();
+        if (boost != null) {
+            instance.getDataManager().deleteBoost(boost);
+        }
+        instance.getDataManager().getUpdater().sendBoostRemove(null);
 
         instance.getLocale().getMessage("command.removeglobalboost.success")
                 .sendPrefixedMessage(sender);

--- a/src/main/java/com/songoda/epiclevels/database/DataManager.java
+++ b/src/main/java/com/songoda/epiclevels/database/DataManager.java
@@ -38,10 +38,6 @@ public class DataManager extends DataManagerAbstract {
         return this.plugin;
     }
 
-    public void close() {
-        updater.onDisable();
-    }
-
     public DataUpdater getUpdater() {
         return updater;
     }
@@ -146,8 +142,10 @@ public class DataManager extends DataManagerAbstract {
 
                     EPlayer ePlayer = new EPlayer(id, experience, mobKills, playerKills, deaths, killstreak, bestKillstreak);
                     callback.accept(ePlayer);
+                    return;
                 }
             }
+            callback.accept(null);
         });
     }
 
@@ -185,7 +183,11 @@ public class DataManager extends DataManagerAbstract {
     }
 
     public void getPlayer(UUID uuid, Consumer<EPlayer> callback) {
-        this.async(() -> selectPlayer(uuid, callback));
+        this.async(() -> selectPlayer(uuid, (player) -> {
+            if (player != null) {
+                callback.accept(player);
+            }
+        }));
     }
 
     public void getPlayerOrCreate(Player player, Consumer<EPlayer> callback) {

--- a/src/main/java/com/songoda/epiclevels/database/DataUpdater.java
+++ b/src/main/java/com/songoda/epiclevels/database/DataUpdater.java
@@ -1,0 +1,176 @@
+package com.songoda.epiclevels.database;
+
+import com.songoda.core.database.DatabaseConnector;
+import com.songoda.core.locale.Message;
+import com.songoda.core.utils.TimeUtils;
+import com.songoda.epiclevels.EpicLevels;
+import com.songoda.epiclevels.boost.Boost;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class DataUpdater extends DataUpdaterAbstract {
+
+    private final DataManager manager;
+
+    private final List<UUID> toUpdate = new ArrayList<>();
+
+    public DataUpdater(DataManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public void onEnable() {
+        super.onEnable();
+
+        if (isEnabled()) {
+            Bukkit.getScheduler().runTaskTimerAsynchronously(manager.getPlugin(), () -> getMessages(this::processMessage), 20, 20);
+            Bukkit.getScheduler().runTaskTimerAsynchronously(manager.getPlugin(), this::cleanMessages, 20, 600);
+        }
+    }
+
+    @Override
+    public void onDisable() {
+        setEnabled(false);
+        toUpdate.clear();
+    }
+
+    public DataManager getManager() {
+        return manager;
+    }
+
+    @Override
+    public DatabaseConnector getConnector() {
+        return manager.getDatabaseConnector();
+    }
+
+    @Override
+    public String getTablePrefix() {
+        return manager.getTablePrefix();
+    }
+
+    public void sendUpdate(String id, Object... args) {
+        String[] strings = new String[args.length];
+        for (int i = 0; i < args.length; i++) {
+            strings[i] = String.valueOf(args[i]);
+        }
+        String msg = id + (args.length > 1 ? ":" + args.length : "") + "=" + String.join("_|||_", strings);
+        if (isEnabled()) {
+            Bukkit.getScheduler().runTaskAsynchronously(manager.getPlugin(), () -> sendMessage(msg));
+        }
+    }
+
+    public void sendPlayerUpdate(UUID uuid) {
+        sendUpdate("PLAYERUPDATE", uuid);
+    }
+
+    public void sendBoostCreate(UUID uuid, long duration, double multiplier, String sender) {
+        sendUpdate("BOOSTCREATE", uuid, duration, multiplier, sender);
+    }
+
+    public void sendBoostRemove(UUID uuid) {
+        sendUpdate("BOOSTREMOVE", uuid);
+    }
+
+    public void processMessage(String msg) {
+        String[] split = msg.split("=", 2);
+        if (split.length < 2) {
+            return;
+        }
+        String[] type = split[0].split(":");
+        if (type.length < 1) {
+            return;
+        }
+        String id = type[0];
+        int length = type.length > 1 ? Integer.parseInt(type[1]) : 1;
+
+        String[] args;
+        if (length <= 1) {
+            args = new String[] {split[1]};
+        } else {
+            args = split[1].split("_\\|\\|\\|_", length);
+            if (args.length != length) {
+                return;
+            }
+        }
+        try {
+            processUpdate(id, args);
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+    }
+
+    public void processUpdate(String id, String[] args) {
+        switch (id.toUpperCase()) {
+            case "PLAYERUPDATE":
+                processPlayerUpdate(UUID.fromString(args[0]));
+                return;
+            case "BOOSTCREATE":
+                processBoostCreate(
+                        args[0].equalsIgnoreCase("null") ? null : UUID.fromString(args[0]),
+                        Long.parseLong(args[1]),
+                        Double.parseDouble(args[2]),
+                        args[3]
+                        );
+                return;
+            case "BOOSTREMOVE":
+                processBoostRemove(args[0].equalsIgnoreCase("null") ? null : UUID.fromString(args[0]));
+        }
+    }
+
+    public void processPlayerUpdate(UUID uuid) {
+        if (toUpdate.contains(uuid)) {
+            return;
+        } else {
+            toUpdate.add(uuid);
+        }
+        Bukkit.getScheduler().runTaskLaterAsynchronously(manager.getPlugin(), () -> {
+            try {
+                Player player = Bukkit.getPlayer(uuid);
+                if (player == null || !player.isOnline()) {
+                    manager.selectPlayer(uuid, (data) -> EpicLevels.getInstance().getPlayerManager().addPlayer(data));
+                }
+            } catch (Throwable t) {
+                t.printStackTrace();
+            }
+            toUpdate.remove(uuid);
+        }, 80);
+    }
+
+    public void processBoostCreate(UUID uuid, long duration, double multiplier, String sender) {
+        Boost boost = new Boost(duration + System.currentTimeMillis(), multiplier);
+
+        if (uuid == null) {
+            // Global boost
+            EpicLevels.getInstance().getBoostManager().setGlobalBoost(boost);
+            Message message = EpicLevels.getInstance().getLocale().getMessage("event.boost.globalannounce")
+                    .processPlaceholder("duration", TimeUtils.makeReadable(duration))
+                    .processPlaceholder("multiplier", multiplier)
+                    .processPlaceholder("player", sender);
+
+            Bukkit.getOnlinePlayers().forEach(message::sendPrefixedMessage);
+        } else {
+            // Player boost
+            EpicLevels.getInstance().getBoostManager().addBoost(uuid, boost);
+            Player player = Bukkit.getPlayer(uuid);
+            if (player != null && player.isOnline()) {
+                EpicLevels.getInstance().getLocale().getMessage("event.boost.announce")
+                        .processPlaceholder("duration", TimeUtils.makeReadable(duration))
+                        .processPlaceholder("multiplier", multiplier)
+                        .processPlaceholder("player", sender)
+                        .sendPrefixedMessage(player);
+            }
+        }
+    }
+
+    public void processBoostRemove(UUID uuid) {
+        if (uuid == null) {
+            EpicLevels.getInstance().getBoostManager().clearGlobalBoost();
+        } else {
+            EpicLevels.getInstance().getBoostManager().removeBoost(uuid);
+        }
+    }
+}

--- a/src/main/java/com/songoda/epiclevels/database/DataUpdater.java
+++ b/src/main/java/com/songoda/epiclevels/database/DataUpdater.java
@@ -34,7 +34,7 @@ public class DataUpdater extends DataUpdaterAbstract {
 
     @Override
     public void onDisable() {
-        setEnabled(false);
+        super.onDisable();
         toUpdate.clear();
     }
 
@@ -107,7 +107,7 @@ public class DataUpdater extends DataUpdaterAbstract {
         switch (id.toUpperCase()) {
             case "PLAYERUPDATE":
                 processPlayerUpdate(UUID.fromString(args[0]));
-                return;
+                break;
             case "BOOSTCREATE":
                 processBoostCreate(
                         args[0].equalsIgnoreCase("null") ? null : UUID.fromString(args[0]),
@@ -115,9 +115,12 @@ public class DataUpdater extends DataUpdaterAbstract {
                         Double.parseDouble(args[2]),
                         args[3]
                         );
-                return;
+                break;
             case "BOOSTREMOVE":
                 processBoostRemove(args[0].equalsIgnoreCase("null") ? null : UUID.fromString(args[0]));
+                break;
+            default:
+                throw new IllegalArgumentException("Cannot process update with the ID: " + id);
         }
     }
 

--- a/src/main/java/com/songoda/epiclevels/database/DataUpdaterAbstract.java
+++ b/src/main/java/com/songoda/epiclevels/database/DataUpdaterAbstract.java
@@ -44,6 +44,7 @@ public abstract class DataUpdaterAbstract {
     }
 
     public void onDisable() {
+        enabled = false;
     }
 
     public abstract DatabaseConnector getConnector();

--- a/src/main/java/com/songoda/epiclevels/database/DataUpdaterAbstract.java
+++ b/src/main/java/com/songoda/epiclevels/database/DataUpdaterAbstract.java
@@ -1,0 +1,127 @@
+package com.songoda.epiclevels.database;
+
+import com.songoda.core.database.DatabaseConnector;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+
+public abstract class DataUpdaterAbstract {
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private long currentID = -1;
+    private boolean enabled = false;
+
+    public void onEnable() {
+        getConnector().connect(connection -> {
+            // Taken from LuckPerms
+            String createTable = "CREATE TABLE IF NOT EXISTS `" + getTablePrefix() + "messenger` (`id` INT AUTO_INCREMENT NOT NULL, `time` TIMESTAMP NOT NULL, `msg` TEXT NOT NULL, PRIMARY KEY (`id`)) DEFAULT CHARSET = utf8mb4";
+            try (Statement statement = connection.createStatement()) {
+                try {
+                    statement.execute(createTable);
+                } catch (SQLException e) {
+                    if (e.getMessage().contains("Unknown character set")) {
+                        statement.execute(createTable.replace("utf8mb4", "utf8"));
+                    } else {
+                        throw e;
+                    }
+                }
+            }
+
+            try (PreparedStatement statement = connection.prepareStatement("SELECT MAX(`id`) as `latest` FROM `" + getTablePrefix() + "messenger`")) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    if (resultSet.next()) {
+                        currentID = resultSet.getLong("latest");
+                    }
+                }
+            }
+            enabled = true;
+        });
+    }
+
+    public void onDisable() {
+    }
+
+    public abstract DatabaseConnector getConnector();
+
+    public abstract String getTablePrefix();
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public void sendMessage(String msg) {
+        lock.readLock().lock();
+        if (!isEnabled()) {
+            lock.readLock().unlock();
+            return;
+        }
+
+        try {
+            getConnector().connect(connection -> {
+                try (PreparedStatement statement = connection.prepareStatement("INSERT INTO `" + getTablePrefix() + "messenger` (`time`, `msg`) VALUES(NOW(), ?)")) {
+                    statement.setString(1, msg);
+                    statement.execute();
+                }
+            });
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+        lock.readLock().unlock();
+    }
+
+    public void getMessages(Consumer<String> callback) {
+        lock.readLock().lock();
+        if (!isEnabled()) {
+            lock.readLock().unlock();
+            return;
+        }
+
+        try {
+            getConnector().connect(connection -> {
+                try (PreparedStatement statement = connection.prepareStatement("SELECT `id`, `msg` FROM `" + getTablePrefix() + "messenger` WHERE `id` > ? AND (NOW() - `time` < 30)")) {
+                    statement.setLong(1, currentID);
+                    try (ResultSet rs = statement.executeQuery()) {
+                        while (rs.next()) {
+                            long id = rs.getLong("id");
+                            currentID = Math.max(currentID, id);
+
+                            String message = rs.getString("msg");
+                            callback.accept(message);
+                        }
+                    }
+                }
+            });
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+        lock.readLock().unlock();
+    }
+
+    public void cleanMessages() {
+        lock.readLock().lock();
+        if (!isEnabled()) {
+            lock.readLock().unlock();
+            return;
+        }
+
+        try {
+            getConnector().connect(connection -> {
+                try (PreparedStatement statement = connection.prepareStatement("DELETE FROM `" + getTablePrefix() + "messenger` WHERE (NOW() - `time` > 60)")) {
+                    statement.execute();
+                }
+            });
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+        lock.readLock().unlock();
+    }
+}

--- a/src/main/java/com/songoda/epiclevels/database/DataUpdaterAbstract.java
+++ b/src/main/java/com/songoda/epiclevels/database/DataUpdaterAbstract.java
@@ -60,11 +60,10 @@ public abstract class DataUpdaterAbstract {
     }
 
     public void sendMessage(String msg) {
-        lock.readLock().lock();
         if (!isEnabled()) {
-            lock.readLock().unlock();
             return;
         }
+        lock.readLock().lock();
 
         try {
             getConnector().connect(connection -> {
@@ -80,11 +79,10 @@ public abstract class DataUpdaterAbstract {
     }
 
     public void getMessages(Consumer<String> callback) {
-        lock.readLock().lock();
         if (!isEnabled()) {
-            lock.readLock().unlock();
             return;
         }
+        lock.readLock().lock();
 
         try {
             getConnector().connect(connection -> {
@@ -108,11 +106,10 @@ public abstract class DataUpdaterAbstract {
     }
 
     public void cleanMessages() {
-        lock.readLock().lock();
         if (!isEnabled()) {
-            lock.readLock().unlock();
             return;
         }
+        lock.readLock().lock();
 
         try {
             getConnector().connect(connection -> {

--- a/src/main/java/com/songoda/epiclevels/listeners/LoginListeners.java
+++ b/src/main/java/com/songoda/epiclevels/listeners/LoginListeners.java
@@ -19,7 +19,8 @@ public class LoginListeners implements Listener {
     @EventHandler
     public void onLogin(PlayerLoginEvent event) {
         Bukkit.getScheduler().runTaskLater(plugin,
-                () -> plugin.getDataManager().getPlayer(event.getPlayer(), (ePlayer -> plugin.getPlayerManager().addPlayer(ePlayer))),
+                () -> EpicLevels.getInstance().getDataManager().getPlayerOrCreate(event.getPlayer(),
+                        player -> plugin.getPlayerManager().addPlayer(player)),
                 30L);
     }
 

--- a/src/main/java/com/songoda/epiclevels/players/EPlayer.java
+++ b/src/main/java/com/songoda/epiclevels/players/EPlayer.java
@@ -174,7 +174,7 @@ public class EPlayer {
         return lastLevel;
     }
 
-    public static int experience(int level) {
+    public static double experience(int level) {
         Formula formula = Formula.valueOf(Settings.LEVELING_FORMULA.getString());
         switch (formula) {
             case EXPONENTIAL: {
@@ -182,16 +182,16 @@ public class EPlayer {
                 for (int i = 1; i < level; i++)
                     a += Math.floor(i + Settings.EXPONENTIAL_BASE.getDouble()
                             * Math.pow(2, (i / Settings.EXPONENTIAL_DIVISOR.getDouble())));
-                return (int) Math.floor(a);
+                return Math.floor(a);
             }
             case LINEAR: {
-                int a = 0;
+                double a = 0;
                 for (int i = 1; i < level; i++)
-                    a += Settings.LINEAR_INCREMENT.getInt();
+                    a += Settings.LINEAR_INCREMENT.getDouble();
                 return a;
             }
             case CUSTOM: {
-                return (int) Math.round(MathUtils.eval(Settings.CUSTOM_FORMULA.getString()
+                return Math.round(MathUtils.eval(Settings.CUSTOM_FORMULA.getString()
                         .replace("level", String.valueOf(level))));
             }
         }

--- a/src/main/java/com/songoda/epiclevels/players/PlayerManager.java
+++ b/src/main/java/com/songoda/epiclevels/players/PlayerManager.java
@@ -60,4 +60,8 @@ public class PlayerManager {
     public long getLastUpdate() {
         return this.lastUpdate;
     }
+
+    public boolean containsPlayer(UUID uuid) {
+        return registeredPlayers.containsKey(uuid);
+    }
 }

--- a/src/main/java/com/songoda/epiclevels/players/PlayerManager.java
+++ b/src/main/java/com/songoda/epiclevels/players/PlayerManager.java
@@ -18,12 +18,8 @@ public class PlayerManager {
 
     public EPlayer getPlayer(UUID uuid) {
         return registeredPlayers.computeIfAbsent(uuid, u -> {
-            EPlayer ePlayer = new EPlayer(uuid);
-            EpicLevels.getInstance().getDataManager().createPlayer(ePlayer);
-
-            this.lastUpdate = System.currentTimeMillis();
-
-            return ePlayer;
+            EpicLevels.getInstance().getDataManager().getPlayerOrCreate(uuid, this::addPlayer);
+            return new EPlayer(uuid);
         });
     }
 


### PR DESCRIPTION
Sometimes I see this error when someone login and their data is deleted, so I fixed it.
> [EpicLevels] An error occurred executing a MySQL query: Duplicate entry 'b1532110-c636-32f8-ac4c-baab98bf3514' for key 'PRIMARY'
> com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException: Duplicate entry 'b1532110-c636-32f8-ac4c-baab98bf3514' for key 'PRIMARY'

I also fixed a problem when a player has a lot of experience.

### Changes
*  Added `DataManager#getPlayerOrCreate(UUID, Consumer)` method.
*  When player data does not exist on registeredPlayers, the data will be obtained with getPlayerOrCreate (Completely async).
*  Now experience calculator return a double value.

## Update (2022/08/05)

Mysql database connector now have an messenger to tell other servers connected at the same database when playerdata/boost need to be updated.

### Changes
*  Added DataUpdaterAbstract and DataUpdater.
*  Now `BoostManager#clearGlobalBoost` return the global boost.
*  Now commands to add/remove boosts can handle offline players data.